### PR TITLE
feat: 청약 공고 카드 컴포넌트 제작

### DIFF
--- a/src/components/subscription/SubscriptionCard.vue
+++ b/src/components/subscription/SubscriptionCard.vue
@@ -1,1 +1,190 @@
 <!-- 기본 카드 컴포넌트 -->
+<template>
+    <div
+        class="bg-white rounded-2xl border border-gray-200 p-4 shadow-sm hover:shadow-md transition-shadow duration-200"
+    >
+        <!-- 상단: 제목, D-Day, 하트 -->
+        <div class="flex items-start justify-between mb-3">
+            <h2 class="text-lg font-bold text-gray-900 flex-1 pr-4">
+                {{ subscription.title }}
+            </h2>
+            <div class="flex items-center gap-2 flex-shrink-0">
+                <!-- D-Day 배지 -->
+                <span
+                    :class="getDDayBadgeClass(getDDayInfo(subscription.applicationCompleteDate).dDay)"
+                    class="text-xs font-semibold px-3 py-1 rounded-md"
+                >
+                    {{ getDDayInfo(subscription.applicationCompleteDate).text }}
+                </span>
+                <!-- 하트 아이콘 -->
+                <button
+                    @click="toggleFavorite"
+                    class="p-1 hover:bg-gray-50 rounded-full transition-colors duration-200"
+                >
+                    <Heart
+                        :size="24"
+                        :fill="isFavorite ? '#ef4444' : 'none'"
+                        :class="isFavorite ? 'text-red-500' : 'text-gray-400'"
+                        stroke-width="1.5"
+                    />
+                </button>
+            </div>
+        </div>
+
+        <!-- 위치 정보 -->
+        <p class="text-gray-500 text-sm mb-2">
+            {{ subscription.location }}
+        </p>
+
+        <!-- 하단: 날짜, 면적/층수, 버튼들 -->
+        <div class="flex items-end justify-between">
+            <!-- 좌측: 날짜 정보 -->
+            <div class="flex flex-col gap-4">
+                <span class="text-gray-500 text-sm">
+                    {{ subscription.applicationStartDate }} - {{ subscription.applicationCompleteDate }}
+                </span>
+                <!-- 아파트 타입 버튼 -->
+                <button
+                    :class="getHouseTypeBadgeClass(subscription.type)"
+                    class="bg-blue-50 w-fit text-blue-700 text-xs font-medium px-3 py-1 rounded-full border border-blue-200"
+                >
+                    {{ subscription.type }}
+                </button>
+            </div>
+
+            <!-- 우측: 버튼들 -->
+            <div class="flex flex-col gap-2 items-end">
+                <!-- 세대수, 가격 -->
+                <span class="text-gray-500 text-md text-gray-500">
+                    {{ subscription.squareMeters }}㎡ · {{ subscription.price }}
+                </span>
+                <!-- 상세보기 버튼 -->
+                <button
+                    @click="handleDetailClick"
+                    class="bg-blue-500 text-white text-sm font-medium px-6 py-2 rounded-md"
+                >
+                    상세보기
+                </button>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { Heart } from 'lucide-vue-next'
+
+// Props 정의
+const props = defineProps({
+  subscription: {
+    type: Object,
+    required: true,
+    default: () => ({
+      id: 1,
+      title: 'e편한세상 아파트',
+      location: '인천시 연수구 송도동',
+      totalUnits: 1000,
+      applicationStartDate: '2025.07.15',
+      applicationCompleteDate: '2025.07.17',
+      status: 'available',
+      type: '분양권',
+      priceRange: '12억',
+      completionDate: '2027.03',
+      features: ['역세권', '대단지']
+    })
+  },
+  favoriteDefault: {
+    type: Boolean,
+    default: false
+  }
+});
+
+// 즐겨찾기 상태
+const isFavorite = ref(props.favoriteDefault)
+
+const toggleFavorite = () => {
+    isFavorite.value = !isFavorite.value
+    emit('favorite-changed', {
+        subscriptionId: props.subscription.id,
+        isFavorite: isFavorite.value,
+    })
+}
+
+// D-Day 계산 함수
+const getDDayInfo = (applicationCompleteDate) => {
+  // applicationCompleteDate 형식: "2025.07.17"
+  if (!applicationCompleteDate) return { dDay: 0, text: 'D-Day' };
+  
+  // 디버깅용 로그
+  console.log('입력된 마감일:', applicationCompleteDate);
+  
+  // 날짜 파싱 (2025.07.17 -> 2025-07-17)
+  const formattedDate = applicationCompleteDate.replace(/\./g, '-');
+  console.log('변환된 날짜:', formattedDate);
+  
+  const endDate = new Date(formattedDate);
+  const today = new Date();
+  
+  console.log('마감일:', endDate);
+  console.log('오늘:', today);
+  
+  // 시간 제거하고 날짜만 비교
+  today.setHours(0, 0, 0, 0);
+  endDate.setHours(0, 0, 0, 0);
+  
+  console.log('시간 제거 후 마감일:', endDate);
+  console.log('시간 제거 후 오늘:', today);
+  
+  const diffTime = endDate - today;
+  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+  
+  console.log('시간 차이(밀리초):', diffTime);
+  console.log('일수 차이:', diffDays);
+  
+  if (diffDays > 0) {
+    console.log('결과: D-' + diffDays);
+    return { dDay: diffDays, text: `D-${diffDays}` };
+  } else if (diffDays === 0) {
+    console.log('결과: D-DAY');
+    return { dDay: 0, text: 'D-DAY' };
+  } else {
+    console.log('결과: 마감');
+    return { dDay: diffDays, text: '마감' };
+  }
+};
+
+// D-Day에 따른 배지 스타일
+const getDDayBadgeClass = (dDay) => {
+    if (dDay > 7) {
+        return 'bg-blue-100 text-blue-700' // 여유있음
+    } else if (dDay > 3) {
+        return 'bg-yellow-100 text-yellow-700' // 곧 마감
+    } else if (dDay >= 0) {
+        return 'bg-red-100 text-red-700' // 임박/당일
+    } else {
+        return 'bg-gray-100 text-gray-700' // 마감됨
+    }
+}
+
+// 집 유형에 따른 배지 스타일
+const getHouseTypeBadgeClass = (type) => {
+    if (type == '아파트') {
+        return 'bg-blue-50 text-blue-700 border border-blue-200'
+    } else if (type == '도시형 생활주택') {
+        return 'bg-yellow-50 text-yellow-700 border border-yellow-200'
+    } else if (type == '오피스텔') {
+        return 'bg-red-50 text-red-700 border border-red-200'
+    } else {
+        return 'bg-gray-100 text-gray-700'
+    }
+}
+
+// 이벤트 emit (부모 컴포넌트에서 사용할 경우)
+const emit = defineEmits(['favorite-changed', 'detail-click'])
+
+const handleDetailClick = () => {
+    emit('detail-click', props.subscription)
+}
+
+
+</script>

--- a/src/pages/subscription/SubscriptionList.vue
+++ b/src/pages/subscription/SubscriptionList.vue
@@ -72,37 +72,34 @@ const filteredSubscriptions = computed(() => {
   // 정렬 적용
   switch (selectedFilter.value) {
     case 'latest':
-      // 최신순 정렬 (ID 기준 내림차순)
-      result.sort((a, b) => b.id - a.id);
-      break;
-      
-    case 'deadline-first':
-      // 마감임박순 정렬 (D-Day 오름차순)
+      // 최신순 정렬 (신청 시작일이 빠른 순)
       result.sort((a, b) => {
-        const aDDay = calculateDDay(a.applicationPeriod);
-        const bDDay = calculateDDay(b.applicationPeriod);
-        
-        // 마감된 것들(-값)은 맨 뒤로
-        if (aDDay < 0 && bDDay >= 0) return 1;
-        if (bDDay < 0 && aDDay >= 0) return -1;
-        if (aDDay < 0 && bDDay < 0) return b.id - a.id; // 둘 다 마감이면 최신순
-        
-        return aDDay - bDDay; // D-Day 오름차순
+        const aStartDate = new Date(a.applicationStartDate.replace(/\./g, '-'));
+        const bStartDate = new Date(b.applicationStartDate.replace(/\./g, '-'));
+        return aStartDate - bStartDate;
       });
       break;
       
-    case 'filter':
-      // 필터 옵션은 현재 상태 유지 (추후 모달 구현 가능)
+    case 'deadline-first':
+      // 마감임박순 정렬 (마감일이 빠른 순)
+      result.sort((a, b) => {
+        const aCompleteDate = new Date(a.applicationCompleteDate.replace(/\./g, '-'));
+        const bCompleteDate = new Date(b.applicationCompleteDate.replace(/\./g, '-'));
+        return aCompleteDate - bCompleteDate;
+      });
       break;
       
     default:
       // 기본은 최신순
-      result.sort((a, b) => b.id - a.id);
+      result.sort((a, b) => {
+        const aStartDate = new Date(a.applicationStartDate.replace(/\./g, '-'));
+        const bStartDate = new Date(b.applicationStartDate.replace(/\./g, '-'));
+        return aStartDate - bStartDate;
+      });
   }
   
   return result;
 });
-
 
 
 // 샘플 청약 공고 데이터

--- a/src/pages/subscription/SubscriptionList.vue
+++ b/src/pages/subscription/SubscriptionList.vue
@@ -1,13 +1,191 @@
 <template>
-  <div class="flex flex-col items-center justify-center min-h-screen bg-white text-center px-6">
-    <h1 class="text-xl font-semibold text-gray-800 mb-2">[청약 공고 목록]</h1>
-    <p class="text-gray-500">이 페이지는 아직 작업 중입니다.</p>
+  <div class="flex flex-col min-h-screen bg-gray-50">
+    <!-- 헤더 -->
+    <div class="sticky top-0 bg-white border-b border-gray-200 px-4 py-4 z-10">
+      <h1 class="text-lg font-semibold text-gray-800 text-center">청약 공고 목록</h1>
+    </div>
+
+    <!-- 필터 버튼들 (옵셔널) -->
+    <div class="px-4 py-3 bg-white border-b border-gray-100 ">
+      <div class="justify-center flex space-x-2 overflow-x-auto">
+        <button 
+          v-for="filter in filters" 
+          :key="filter.key"
+          @click="selectedFilter = filter.key"
+          :class="[
+            'px-4 py-2 rounded-full text-sm whitespace-nowrap transition-colors',
+            selectedFilter === filter.key 
+              ? 'bg-blue-500 text-white' 
+              : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+          ]"
+        >
+          {{ filter.label }}
+        </button>
+      </div>
+    </div>
+
+    <!-- 공고 목록 -->
+    <div class="flex-1 px-4 py-4 pb-20">
+      <div v-if="filteredSubscriptions.length === 0" class="text-center py-12">
+        <p class="text-gray-500">현재 표시할 청약 공고가 없습니다.</p>
+      </div>
+      
+      <div v-else class="space-y-4">
+        <SubscriptionCard 
+          v-for="subscription  in filteredSubscriptions" 
+          :key="subscription.id"
+          :subscription="subscription"
+        />
+      </div>
+    </div>
+
     <BottomNavbar/>
   </div>
 </template>
 
 <script setup>
+import { ref, computed } from 'vue'
 import BottomNavbar from '@/components/common/BottomNavbar.vue';
+import SubscriptionCard from '@/components/subscription/SubscriptionCard.vue';
 
-// 아직 구현할 기능 없음
+const selectedFilter = ref('latest')
+
+const filters = [
+  { key: 'latest', label: '최신순' },
+  { key: 'deadline-first', label: '마감임박순' },
+  { key: 'filter', label: '필터', isCustom: true }
+]
+
+
+// 상세 필터 조건
+const customFilterOptions = [
+  { key: 'location', label: '지역' },
+  { key: 'price', label: '가격대' },
+  { key: 'area', label: '면적(평수)' },
+]
+
+
+// 필터링된 청약 공고 목록
+const filteredSubscriptions = computed(() => {
+  let result = [...subscriptions.value];
+  
+  // 정렬 적용
+  switch (selectedFilter.value) {
+    case 'latest':
+      // 최신순 정렬 (ID 기준 내림차순)
+      result.sort((a, b) => b.id - a.id);
+      break;
+      
+    case 'deadline-first':
+      // 마감임박순 정렬 (D-Day 오름차순)
+      result.sort((a, b) => {
+        const aDDay = calculateDDay(a.applicationPeriod);
+        const bDDay = calculateDDay(b.applicationPeriod);
+        
+        // 마감된 것들(-값)은 맨 뒤로
+        if (aDDay < 0 && bDDay >= 0) return 1;
+        if (bDDay < 0 && aDDay >= 0) return -1;
+        if (aDDay < 0 && bDDay < 0) return b.id - a.id; // 둘 다 마감이면 최신순
+        
+        return aDDay - bDDay; // D-Day 오름차순
+      });
+      break;
+      
+    case 'filter':
+      // 필터 옵션은 현재 상태 유지 (추후 모달 구현 가능)
+      break;
+      
+    default:
+      // 기본은 최신순
+      result.sort((a, b) => b.id - a.id);
+  }
+  
+  return result;
+});
+
+
+
+// 샘플 청약 공고 데이터
+const subscriptions = ref([
+  {
+    id: 1,
+    title: '힐스테이트 청라 국제도시',
+    location: '인천광역시 서구',
+    totalUnits: 1284,
+    applicationStartDate: '2025.08.15',
+    applicationCompleteDate: '2025.08.17',
+    status: 'available',
+    type: '아파트',
+    squareMeters: 104,
+    price: '12억',
+    completionDate: '2027.03',
+  },
+  {
+    id: 2,
+    title: '래미안 원베일리',
+    location: '서울특별시 강동구',
+    totalUnits: 758,
+    applicationStartDate: '2025.07.21',
+    applicationCompleteDate: '2025.07.22',
+    type: '오피스텔',
+    squareMeters: 74,
+    price: '18억',
+    completionDate: '2027.06',
+  },
+  {
+    id: 3,
+    title: '푸르지오 시티 동탄',
+    location: '경기도 화성시',
+    totalUnits: 2156,
+    applicationStartDate: '2025.08.08',
+    applicationCompleteDate: '2025.08.10',
+    type: '아파트',
+    squareMeters: 83,
+    price: '15억',
+    completionDate: '2027.09',
+  },
+  {
+    id: 4,
+    title: '자이 평촌 센트럴파크',
+    location: '경기도 안양시 동안구',
+    totalUnits: 924,
+    applicationStartDate: '2025.08.25',
+    applicationCompleteDate: '2025.08.27',
+    status: 'upcoming',
+    type: '도시형 생활주택',
+    squareMeters: 104,
+    price: '20억',
+    completionDate: '2027.12',
+  },
+  {
+    id: 5,
+    title: '롯데캐슬 베네시티',
+    location: '대구광역시 달서구',
+    totalUnits: 1456,
+    applicationStartDate: '2025.08.12',
+    applicationCompleteDate: '2025.08.14',
+    status: 'available',
+    type: '아파트',
+    squareMeters: 104,
+    price: '9억',
+    completionDate: '2027.08',
+  }
+])
+
+
+
+// 필터 클릭 핸들러
+const handleFilterClick = (filter) => {
+  if (filter.isCustom) {
+    // 필터 버튼 클릭 시 모달이나 추가 옵션 표시 (추후 구현)
+    console.log('필터 옵션 열기');
+    // 여기에 모달 열기 로직 추가 가능
+  } else {
+    selectedFilter.value = filter.key;
+  }
+};
+
+
+
+
 </script>


### PR DESCRIPTION

## ✨ 변경 사항
- 청약 공고 카드 컴포넌트 제작
- 청약 리스트 페이지 초안 제작

---

## 🧪 테스트 방법
1. `/subscriptions` 페이지로 이동
2. 청약 공고 카드 확인

---

## 🔍 관련 이슈
- closes #42 (청약 공고 카드 컴포넌트 제작)

---

## 📝 체크리스트 ✓ 사용해서 표시
- [ ] 동작 테스트 완료
- [ ] 코드 컨벤션 준수
- [ ] 주석, 콘솔 제거
- [ ] 팀원과 사전 공유 완료
